### PR TITLE
Add Claude session start hook for npm dependency installation

### DIFF
--- a/.claude/hooks/session-start.sh
+++ b/.claude/hooks/session-start.sh
@@ -1,0 +1,11 @@
+#!/bin/bash
+set -euo pipefail
+
+# Only run in remote (Claude Code on the web) environments
+if [ "${CLAUDE_CODE_REMOTE:-}" != "true" ]; then
+  exit 0
+fi
+
+# Install npm dependencies for ultrasound-proposal-generator
+cd "$CLAUDE_PROJECT_DIR/ultrasound-proposal-generator"
+npm install

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,0 +1,14 @@
+{
+  "hooks": {
+    "SessionStart": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "$CLAUDE_PROJECT_DIR/.claude/hooks/session-start.sh"
+          }
+        ]
+      }
+    ]
+  }
+}


### PR DESCRIPTION
## Summary
This PR adds a Claude IDE session start hook that automatically installs npm dependencies for the ultrasound-proposal-generator project when working in remote (web-based) environments.

## Key Changes
- Added `.claude/settings.json` configuration file that registers a `SessionStart` hook
- Added `.claude/hooks/session-start.sh` bash script that:
  - Only executes in remote Claude Code environments (checks `CLAUDE_CODE_REMOTE` environment variable)
  - Automatically runs `npm install` in the `ultrasound-proposal-generator` directory on session start
  - Uses strict bash settings (`set -euo pipefail`) for error handling

## Implementation Details
The hook is designed to improve the developer experience by ensuring npm dependencies are always available when starting a new session in the web-based Claude Code environment, while avoiding unnecessary execution in local development setups.

https://claude.ai/code/session_017pcCetgeTypE8oHimnxoBx